### PR TITLE
Use the PyPI canonical form of our name everywhere

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,8 +1,8 @@
 Authors
 =======
 
-``service_identity`` is written and maintained by `Hynek Schlawack <https://hynek.me/>`_.
+``service-identity`` is written and maintained by `Hynek Schlawack <https://hynek.me/>`_.
 
 The development is kindly supported by `Variomedia AG <https://www.variomedia.de/>`_.
 
-Other contributors can be found in `GitHub's overview <https://github.com/pyca/service_identity/graphs/contributors>`_.
+Other contributors can be found in `GitHub's overview <https://github.com/pyca/service-identity/graphs/contributors>`_.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,7 +41,7 @@ Changes:
 - pyOpenSSL is optional now if you use ``service_identity.cryptography.*`` only.
 - Added support for ``iPAddress`` ``subjectAltName``\ s.
   You can now verify whether a connection or a certificate is valid for an IP address using ``service_identity.pyopenssl.verify_ip_address()`` and ``service_identity.cryptography.verify_certificate_ip_address()``.
-  `#12 <https://github.com/pyca/service_identity/pull/12>`_
+  `#12 <https://github.com/pyca/service-identity/pull/12>`_
 
 
 ----
@@ -53,7 +53,7 @@ Changes:
 Deprecations:
 ^^^^^^^^^^^^^
 
-- Since Chrome 58 and Firefox 48 both don't accept certificates that contain only a Common Name, its usage is hereby deprecated in ``service_identity`` too.
+- Since Chrome 58 and Firefox 48 both don't accept certificates that contain only a Common Name, its usage is hereby deprecated in ``service-identity`` too.
   We have been raising a warning since 16.0.0 and the support will be removed in mid-2018 for good.
 
 
@@ -61,12 +61,12 @@ Changes:
 ^^^^^^^^
 
 - When ``service_identity.SubjectAltNameWarning`` is raised, the Common Name of the certificate is now included in the warning message.
-  `#17 <https://github.com/pyca/service_identity/pull/17>`_
+  `#17 <https://github.com/pyca/service-identity/pull/17>`_
 - Added ``cryptography.x509`` backend for verifying certificates.
-  `#18 <https://github.com/pyca/service_identity/pull/18>`_
+  `#18 <https://github.com/pyca/service-identity/pull/18>`_
 - Wildcards (``*``) are now only allowed if they are the leftmost label in a certificate.
   This is common practice by all major browsers.
-  `#19 <https://github.com/pyca/service_identity/pull/19>`_
+  `#19 <https://github.com/pyca/service-identity/pull/19>`_
 
 
 ----
@@ -94,7 +94,7 @@ Changes:
 
 - Officially support Python 3.5.
 - ``service_identity.SubjectAltNameWarning`` is now raised if the server certicate lacks a proper ``SubjectAltName``.
-  `#9 <https://github.com/pyca/service_identity/issues/9>`_
+  `#9 <https://github.com/pyca/service-identity/issues/9>`_
 - Add a ``__str__`` method to ``VerificationError``.
 - Port from ``characteristic`` to its spiritual successor `attrs <https://www.attrs.org/>`_.
 
@@ -130,11 +130,11 @@ Changes:
 
 - Move into the `Python Cryptography Authority’s GitHub account <https://github.com/pyca/>`_.
 - Move exceptions into ``service_identity.exceptions`` so tracebacks don’t contain private module names.
-- Promoting to stable since Twisted 14.0 is optionally depending on ``service_identity`` now.
+- Promoting to stable since Twisted 14.0 is optionally depending on ``service-identity`` now.
 - Use `characteristic <https://characteristic.readthedocs.io/>`_ instead of a home-grown solution.
 - ``idna`` 0.6 did some backward-incompatible fixes that broke Python 3 support.
-  This has been fixed now therefore ``service_identity`` only works with ``idna`` 0.6 and later.
-  Unfortunately since ``idna`` doesn’t offer version introspection, ``service_identity`` can’t warn about it.
+  This has been fixed now therefore ``service-identity`` only works with ``idna`` 0.6 and later.
+  Unfortunately since ``idna`` doesn’t offer version introspection, ``service-identity`` can’t warn about it.
 
 
 ----

--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,8 @@ Service Identity Verification
    :target: https://service-identity.readthedocs.io/en/stable/?badge=stable
    :alt: Documentation Status
 
-.. image:: https://dev.azure.com/pyca/service_identity/_apis/build/status/pyca.service_identity?branchName=master
-   :target: https://dev.azure.com/pyca/service_identity/_build?definitionId=11
+.. image:: https://dev.azure.com/pyca/service-identity/_apis/build/status/pyca.service-identity?branchName=master
+   :target: https://dev.azure.com/pyca/service-identity/_build?definitionId=11
    :alt: CI Status
 
 .. image:: https://codecov.io/github/pyca/service-identity/branch/master/graph/badge.svg

--- a/README.rst
+++ b/README.rst
@@ -10,8 +10,8 @@ Service Identity Verification
    :target: https://dev.azure.com/pyca/service_identity/_build?definitionId=11
    :alt: CI Status
 
-.. image:: https://codecov.io/github/pyca/service_identity/branch/master/graph/badge.svg
-   :target: https://codecov.io/github/pyca/service_identity
+.. image:: https://codecov.io/github/pyca/service-identity/branch/master/graph/badge.svg
+   :target: https://codecov.io/github/pyca/service-identity
    :alt: Test Coverage
 
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
@@ -28,12 +28,12 @@ Use this package if:
 - you use pyOpenSSL_ and don’t want to be MITM_\ ed or
 - if you want to verify that a `PyCA cryptography`_ certificate is valid for a certain hostname or IP address.
 
-``service_identity`` aspires to give you all the tools you need for verifying whether a certificate is valid for the intended purposes.
+``service-identity`` aspires to give you all the tools you need for verifying whether a certificate is valid for the intended purposes.
 
 In the simplest case, this means *host name verification*.
-However, ``service_identity`` implements `RFC 6125`_ fully and plans to add other relevant RFCs too.
+However, ``service-identity`` implements `RFC 6125`_ fully and plans to add other relevant RFCs too.
 
-``service_identity``\ ’s documentation lives at `Read the Docs <https://service-identity.readthedocs.io/>`_, the code on `GitHub <https://github.com/pyca/service_identity>`_.
+``service-identity``\ ’s documentation lives at `Read the Docs <https://service-identity.readthedocs.io/>`_, the code on `GitHub <https://github.com/pyca/service-identity>`_.
 
 
 .. _Twisted: https://twistedmatrix.com/

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6,7 +6,7 @@ API
 
    So far, public APIs are only available for hostnames (RFC 6125) and IP addresses (RFC 2818).
    All IDs specified by RFC 6125 are already implemented though.
-   If you'd like to play with them and provide feedback have a look at the ``verify_service_identity`` function in the `_common module <https://github.com/pyca/service_identity/blob/master/src/service_identity/_common.py>`_.
+   If you'd like to play with them and provide feedback have a look at the ``verify_service_identity`` function in the `_common module <https://github.com/pyca/service-identity/blob/master/src/service_identity/_common.py>`_.
 
 
 pyOpenSSL

--- a/docs/backward-compatibility.rst
+++ b/docs/backward-compatibility.rst
@@ -1,7 +1,7 @@
 Backward Compatibility
 ======================
 
-``service_identity`` has a very strong backward compatibility policy.
+``service-identity`` has a very strong backward compatibility policy.
 Generally speaking, you shouldn't ever be afraid of updating.
 
 If breaking changes are needed do be done, they are:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# service_identity documentation build configuration file, created by
+# service-identity documentation build configuration file, created by
 # sphinx-quickstart on Mon Jun  2 16:32:11 2014.
 #
 # This file is execfile()d with the current directory set to its
@@ -76,7 +76,7 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"service_identity"
+project = u"service-identity"
 year = datetime.date.today().year
 copyright = u"2014, Hynek Schlawack"
 
@@ -216,7 +216,7 @@ html_theme_options = {
 # html_file_suffix = None
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = "service_identitydoc"
+htmlhelp_basename = "service-identitydoc"
 
 
 # -- Options for LaTeX output ---------------------------------------------
@@ -229,7 +229,7 @@ latex_elements = {}
 latex_documents = [
     (
         "index",
-        "service_identity.tex",
+        "service-identity.tex",
         u"service\\_identity Documentation",
         u"Hynek Schlawack",
         "manual",
@@ -264,8 +264,8 @@ latex_documents = [
 man_pages = [
     (
         "index",
-        "service_identity",
-        u"service_identity Documentation",
+        "service-identity",
+        u"service-identity Documentation",
         [u"Hynek Schlawack"],
         1,
     )
@@ -283,10 +283,10 @@ man_pages = [
 texinfo_documents = [
     (
         "index",
-        "service_identity",
-        u"service_identity Documentation",
+        "service-identity",
+        u"service-identity Documentation",
         u"Hynek Schlawack",
-        "service_identity",
+        "service-identity",
         "Service Identity Verification for pyOpenSSL",
         "Miscellaneous",
     )

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,7 +6,7 @@ Installation and Requirements
 Installation
 ============
 
-``$ pip install service_identity``
+``$ pip install service-identity``
 
 
 Requirements

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -1,7 +1,7 @@
 License
 =======
 
-``service_identity`` is licensed under the `MIT <https://choosealicense.com/licenses/mit/>`_ license.
-The full license text can be also found in the `source code repository <https://github.com/pyca/service_identity/blob/master/LICENSE>`_.
+``service-identity`` is licensed under the `MIT <https://choosealicense.com/licenses/mit/>`_ license.
+The full license text can be also found in the `source code repository <https://github.com/pyca/service-identity/blob/master/LICENSE>`_.
 
 .. include:: ../AUTHORS.rst

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 
 ###############################################################################
 
-NAME = "service_identity"
+NAME = "service-identity"
 KEYWORDS = ["cryptography", "openssl", "pyopenssl"]
 CLASSIFIERS = [
     "Development Status :: 5 - Production/Stable",
@@ -57,7 +57,7 @@ EXTRAS_REQUIRE["azure-pipelines"] = EXTRAS_REQUIRE["tests"] + [
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 PACKAGES = find_packages(where="src")
-META_PATH = os.path.join(HERE, "src", NAME, "__init__.py")
+META_PATH = os.path.join(HERE, "src", NAME.replace("-", "_"), "__init__.py")
 
 
 def read(*parts):

--- a/src/service_identity/__init__.py
+++ b/src/service_identity/__init__.py
@@ -14,7 +14,7 @@ from .exceptions import (
 
 __version__ = "19.1.0.dev0"
 
-__title__ = "service_identity"
+__title__ = "service-identity"
 __description__ = "Service identity verification for pyOpenSSL & cryptography."
 __uri__ = "https://service-identity.readthedocs.io/"
 

--- a/src/service_identity/exceptions.py
+++ b/src/service_identity/exceptions.py
@@ -1,5 +1,5 @@
 """
-All exceptions and warnings thrown by ``service_identity``.
+All exceptions and warnings thrown by ``service-identity``.
 
 Separated into an own package for nicer tracebacks, you should still import
 them from __init__.py.

--- a/src/service_identity/pyopenssl.py
+++ b/src/service_identity/pyopenssl.py
@@ -138,7 +138,7 @@ def extract_ids(cert):
             "Certificate with CN '%s' has no `subjectAltName`, falling back "
             "to check for a `commonName` for now.  This feature is being "
             "removed by major browsers and deprecated by RFC 2818.  "
-            "service_identity will remove the support for it in mid-2018."
+            "service-identity will remove the support for it in mid-2018."
             % (cn.decode("utf-8"),),
             SubjectAltNameWarning,
             stacklevel=2,

--- a/tests/test_pyopenssl.py
+++ b/tests/test_pyopenssl.py
@@ -121,7 +121,7 @@ class TestExtractIDs(object):
             "Certificate with CN 'www.microsoft.com' has no `subjectAltName`"
         )
         assert msg.endswith(
-            "service_identity will remove the support for it in mid-2018."
+            "service-identity will remove the support for it in mid-2018."
         )
 
     def test_uri(self):


### PR DESCRIPTION
As announced on IRC, I'd like to introduce more consistency. Shouldn't affect anyone except distro packagers.