### PR TITLE
Add missing six dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,10 +41,11 @@ INSTALL_REQUIRES = [
     # https://github.com/pypa/setuptools/issues/498
     "pyasn1",
     "cryptography",
+    "six",
 ]
 EXTRAS_REQUIRE = {
     "idna": ["idna"],
-    "tests": ["coverage[toml]>=5.0.2", "pytest", "six"],
+    "tests": ["coverage[toml]>=5.0.2", "pytest"],
     "docs": ["sphinx"],
 }
 EXTRAS_REQUIRE["dev"] = (


### PR DESCRIPTION
Package can not import due to undeclared dependency. Tests presumably don't notice because it was in extras_require, but this is what you see in a freshly installed venv :

```
$ python
Python 3.9.1 (default, Jan  8 2021, 17:17:43) 
[Clang 12.0.0 (clang-1200.0.32.28)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import service_identity
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/wim/.venv/lib/python3.9/site-packages/service_identity/__init__.py", line 7, in <module>
    from . import cryptography, pyopenssl
  File "/Users/wim/.venv/lib/python3.9/site-packages/service_identity/pyopenssl.py", line 9, in <module>
    import six
ModuleNotFoundError: No module named 'six'
```