### PR TITLE
Add Tidelift

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,4 @@
 ---
-
 github: hynek
 ko_fi: the_hynek
+tidelift: "pypi/service-identity"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,21 +4,21 @@ repos:
     rev: 21.12b0
     hooks:
       - id: black
-        language_version: python3.8
+        language_version: python3.10
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.8.0
     hooks:
       - id: isort
         additional_dependencies: [toml]
-        language_version: python3.8
+        language_version: python3.10
 
   - repo: https://github.com/pycqa/flake8
     rev: 3.9.0
     hooks:
     - id: flake8
       additional_dependencies: [flake8-bugbear]
-      language_version: python3.8
+      language_version: python3.10
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 21.12b0
     hooks:
       - id: black
         language_version: python3.8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,8 @@ repos:
     rev: 21.12b0
     hooks:
       - id: black
+        # Black needs _unicodefun from click
+        additional_dependencies: [click<8]
         language_version: python3.10
 
   - repo: https://github.com/PyCQA/isort

--- a/README.rst
+++ b/README.rst
@@ -39,12 +39,14 @@ However, ``service-identity`` implements `RFC 6125`_ fully and plans to add othe
 .. _MITM: https://en.wikipedia.org/wiki/Man-in-the-middle_attack
 .. _RFC 6125: https://www.rfc-editor.org/info/rfc6125
 .. _PyCA cryptography: https://cryptography.io/
+
 .. spiel-end
 
 Project Information
 ===================
 
 .. meta-begin
+
 ``service-identity``\ is released under the MIT license, its documentation lives at `Read the Docs <https://service-identity.readthedocs.io/>`_, the code on `GitHub <https://github.com/pyca/service-identity>`_, and the latest release on `PyPI <https://pypi.org/project/service-identity/>`_.
 It’s rigorously tested on Python 2.7, 3.5+, and PyPy.
 

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Service Identity Verification
    :target: https://www.irccloud.com/invite?channel=%23pyca&amp;hostname=irc.libera.chat&amp;port=6697&amp;ssl=1
    :alt: PyCA on IRC
 
-.. begin
+.. spiel-begin
 
 Use this package if:
 
@@ -34,11 +34,26 @@ Use this package if:
 In the simplest case, this means *host name verification*.
 However, ``service-identity`` implements `RFC 6125`_ fully and plans to add other relevant RFCs too.
 
-``service-identity``\ ’s documentation lives at `Read the Docs <https://service-identity.readthedocs.io/>`_, the code on `GitHub <https://github.com/pyca/service-identity>`_.
-
-
 .. _Twisted: https://twistedmatrix.com/
 .. _pyOpenSSL: https://pypi.org/project/pyOpenSSL/
 .. _MITM: https://en.wikipedia.org/wiki/Man-in-the-middle_attack
 .. _RFC 6125: https://www.rfc-editor.org/info/rfc6125
 .. _PyCA cryptography: https://cryptography.io/
+.. spiel-end
+
+Project Information
+===================
+
+.. meta-begin
+``service-identity``\ is released under the MIT license, its documentation lives at `Read the Docs <https://service-identity.readthedocs.io/>`_, the code on `GitHub <https://github.com/pyca/service-identity>`_, and the latest release on `PyPI <https://pypi.org/project/service-identity/>`_.
+It’s rigorously tested on Python 2.7, 3.5+, and PyPy.
+
+
+``service-identity`` for Enterprise
+-----------------------------------
+
+Available as part of the Tidelift Subscription.
+
+The maintainers of ``service-identity`` and thousands of other packages are working with Tidelift to deliver commercial support and maintenance for the open-source packages you use to build your applications.
+Save time, reduce risk, and improve code health, while paying the maintainers of the exact packages you use.
+`Learn more. <https://tidelift.com/subscription/pkg/service-identity?utm_source=undefined&utm_medium=referral&utm_campaign=enterprise&utm_term=repo>`_

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,11 @@
 
 ## Supported Versions
 
-We are following [CalVer](https://calver.org) with generous backward-compatibility guarantees. Therefore we only support the latest version.
+We are following [CalVer](https://calver.org) with generous backwards-compatibility guarantees.
+Therefore we only support the latest version.
 
 
 ## Reporting a Vulnerability
 
-If you think you found a Vulnerability, please contact Hynek Schlawack at <hs@ox.cx>.
-
-If you insist on using PGP, you can use the key `0xAE2536227F69F181`. The fingerprint must be `C2A0 4F86 ACE2 8ADC F817 DBB7 AE25 3622 7F69 F181`.  You can also find it on [Keybase](https://keybase.io/hynek).
+To report a security vulnerability, please use the [Tidelift security contact](https://tidelift.com/security).
+Tidelift will coordinate the fix and disclosure.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,8 @@ Service Identity Verification for pyOpenSSL & cryptography
 Release v\ |release| (:doc:`What's new? <changelog>`).
 
 .. include:: ../README.rst
-   :start-after: begin
+   :start-after: spiel-begin
+   :end-before: spiel-end
 
 
 User's Guide
@@ -20,7 +21,10 @@ User's Guide
 
 
 Project Information
--------------------
+===================
+
+.. include:: ../README.rst
+   :start-after: meta-begin
 
 .. toctree::
    :maxdepth: 1

--- a/tox.ini
+++ b/tox.ini
@@ -13,9 +13,9 @@ python =
     3.5: py35
     3.6: py36
     3.7: py37, docs
-    3.8: py38, lint, manifest
+    3.8: py38, manifest
     3.9: py39
-    3.10: py310
+    3.10: py310, lint
 
 
 [tox]
@@ -40,7 +40,7 @@ commands =
 
 
 [testenv:lint]
-basepython = python3.8
+basepython = python3.10
 skip_install = true
 deps = pre-commit
 passenv = HOMEPATH  # needed on Windows


### PR DESCRIPTION
service-identity is now lifted at Tidelift, therefore I need to add some docs. The readme and main docs page is a bit re-structured since it looked odd otherwise.