### PR TITLE
Make extract_patterns along with patterns public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,9 @@ If breaking changes are needed do be done, they are:
 
 ### Changes
 
-- `service_identity.cryptography.extract_ids()` and `service_identity.pyopenssl.extract_ids()` are now public APIs.
+- `service_identity.(cryptography|pyopenssl).extract_ids()` are now public APIs.
   You can use them to extract the patterns from a certificate without verifying anything.
+  [#55](https://github.com/pyca/service-identity/pull/55)
 
 
 ## 21.1.0 (2021-05-09)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ If breaking changes are needed do be done, they are:
 
 ### Changes
 
-- `service_identity.(cryptography|pyopenssl).extract_ids()` are now public APIs.
+- `service_identity.(cryptography|pyopenssl).extract_patterns()` are now public APIs (FKA `extract_ids()`).
   You can use them to extract the patterns from a certificate without verifying anything.
   [#55](https://github.com/pyca/service-identity/pull/55)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,16 @@ If breaking changes are needed do be done, they are:
   When using such an old pyOpenSSL version, you have to pin *cryptography* yourself to ensure compatibility between them.
   Please check out [`contraints/oldest-pyopenssl.txt`](https://github.com/pyca/service-identity/blob/main/constraints/oldest-pyopenssl.txt) to verify what we are testing against.
 
+
 ### Deprecations
 
 *none*
 
+
 ### Changes
 
-*none*
+- `service_identity.cryptography.extract_ids()` and `service_identity.pyopenssl.extract_ids()` are now public APIs.
+  You can use them to extract the patterns from a certificate without verifying anything.
 
 
 ## 21.1.0 (2021-05-09)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ If breaking changes are needed do be done, they are:
 
 <!-- changelog follows -->
 
-## XX.Y.Z (UNRELEASED)
+## [Unreleased](https://github.com/pyca/service-identity/compare/21.1.0...HEAD)
 
 ### Backwards-incompatible Changes
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,12 @@
 
 Use this package if:
 
-- you want to verify that a [PyCA cryptography](https://cryptography.io/) certificate is valid for a certain hostname or IP address
-- or if you use [pyOpenSSL](https://pypi.org/project/pyOpenSSL/) and don’t want to be [MITM](https://en.wikipedia.org/wiki/Man-in-the-middle_attack)ed.
+- you want to **verify** that a [PyCA cryptography](https://cryptography.io/) certificate is valid for a certain hostname or IP address,
+- or if you use [pyOpenSSL](https://pypi.org/project/pyOpenSSL/) and don’t want to be [**MITM**](https://en.wikipedia.org/wiki/Man-in-the-middle_attack)ed,
+- or if you want to **inspect** certificates from either for service IDs.
 
-*service-identity* aspires to give you all the tools you need for verifying whether a certificate is valid for the intended purposes. In the simplest case, this means *host name verification*.
+*service-identity* aspires to give you all the tools you need for verifying whether a certificate is valid for the intended purposes.
+In the simplest case, this means *host name verification*.
 However, *service-identity* implements [RFC 6125](https://datatracker.ietf.org/doc/html/rfc6125.html) fully.
 
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 Use this package if:
 
-- you want to **verify** that a [PyCA cryptography](https://cryptography.io/) certificate is valid for a certain hostname or IP address,
+- you want to **verify** that a [PyCA *cryptography*](https://cryptography.io/) certificate is valid for a certain hostname or IP address,
 - or if you use [pyOpenSSL](https://pypi.org/project/pyOpenSSL/) and don’t want to be [**MITM**](https://en.wikipedia.org/wiki/Man-in-the-middle_attack)ed,
 - or if you want to **inspect** certificates from either for service IDs.
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -16,7 +16,7 @@ PyCA cryptography
 
 .. autofunction:: verify_certificate_hostname
 .. autofunction:: verify_certificate_ip_address
-.. autofunction:: extract_ids
+.. autofunction:: extract_patterns
 
 
 pyOpenSSL
@@ -32,14 +32,14 @@ pyOpenSSL
       :literal:
 
 .. autofunction:: verify_ip_address
-.. autofunction:: extract_ids
+.. autofunction:: extract_patterns
 
 
 Pattern Objects
 ===============
 
-The following are the objects return by the ``extract_ids`` functions.
-They each carry the attributes that are necessary to match a pattern of their type.
+The following are the objects return by the ``extract_patterns`` functions.
+They each carry the attributes that are necessary to match an ID of their type.
 
 .. currentmodule:: service_identity.common
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6,7 +6,7 @@ API
 
    So far, public APIs are only available for host names (:rfc:`6125`) and IP addresses (:rfc:`2818`).
    All IDs specified by :rfc:`6125` are already implemented though.
-   If you'd like to play with them and provide feedback have a look at the ``verify_service_identity`` function in the `_common module <https://github.com/pyca/service-identity/blob/main/src/service_identity/_common.py>`_.
+   If you'd like to play with them and provide feedback have a look at the ``verify_service_identity`` function in the `common module <https://github.com/pyca/service-identity/blob/main/src/service_identity/common.py>`_.
 
 
 PyCA cryptography
@@ -16,6 +16,7 @@ PyCA cryptography
 
 .. autofunction:: verify_certificate_hostname
 .. autofunction:: verify_certificate_ip_address
+.. autofunction:: extract_ids
 
 
 pyOpenSSL
@@ -31,6 +32,25 @@ pyOpenSSL
       :literal:
 
 .. autofunction:: verify_ip_address
+.. autofunction:: extract_ids
+
+
+Pattern Objects
+===============
+
+The following are the objects return by the ``extract_ids`` functions.
+They each carry the attributes that are necessary to match a pattern of their type.
+
+.. currentmodule:: service_identity.common
+
+.. autoclass:: DNSPattern
+   :members:
+.. autoclass:: IPAddressPattern
+   :members:
+.. autoclass:: URIPattern
+   :members:
+.. autoclass:: SRVPattern
+   :members:
 
 
 Universal Errors and Warnings

--- a/docs/pyopenssl_example.py
+++ b/docs/pyopenssl_example.py
@@ -22,7 +22,7 @@ conn.connect((hostname, 443))
 try:
     conn.do_handshake()
 
-    print("Certificate is valid for the following patterns:\n")
+    print("Server certificate is valid for the following patterns:\n")
     pprint.pprint(
         service_identity.pyopenssl.extract_patterns(
             conn.get_peer_certificate()

--- a/docs/pyopenssl_example.py
+++ b/docs/pyopenssl_example.py
@@ -22,9 +22,11 @@ conn.connect((hostname, 443))
 try:
     conn.do_handshake()
 
-    print("IDs in certificate:\n")
+    print("Certificate is valid for the following patterns:\n")
     pprint.pprint(
-        service_identity.pyopenssl.extract_ids(conn.get_peer_certificate())
+        service_identity.pyopenssl.extract_patterns(
+            conn.get_peer_certificate()
+        )
     )
 
     try:

--- a/docs/pyopenssl_example.py
+++ b/docs/pyopenssl_example.py
@@ -1,29 +1,39 @@
+import pprint
 import socket
+import sys
+
+import idna
 
 from OpenSSL import SSL
 
-from service_identity import VerificationError
-from service_identity.pyopenssl import verify_hostname
+import service_identity
 
+
+hostname = sys.argv[1]
 
 ctx = SSL.Context(SSL.SSLv23_METHOD)
 ctx.set_verify(SSL.VERIFY_PEER, lambda conn, cert, errno, depth, ok: ok)
 ctx.set_default_verify_paths()
 
-hostname = "hynek.me"
 conn = SSL.Connection(ctx, socket.socket(socket.AF_INET, socket.SOCK_STREAM))
+conn.set_tlsext_host_name(idna.encode(hostname))
 conn.connect((hostname, 443))
 
 try:
     conn.do_handshake()
-    verify_hostname(conn, hostname)
 
-    print(f"Certificate is valid for {hostname}!")
-    # Do your super-secure stuff here.
+    print("IDs in certificate:\n")
+    pprint.pprint(
+        service_identity.pyopenssl.extract_ids(conn.get_peer_certificate())
+    )
+
+    try:
+        service_identity.pyopenssl.verify_hostname(conn, hostname)
+    except service_identity.VerificationError:
+        print(f"\nPresented certificate is NOT valid for {hostname}.")
+    finally:
+        conn.shutdown()
 except SSL.Error as e:
     print(f"TLS Handshake failed: {e!r}.")
-except VerificationError:
-    print(f"Presented certificate is not valid for {hostname}.")
 finally:
-    conn.shutdown()
     conn.close()

--- a/src/service_identity/__init__.py
+++ b/src/service_identity/__init__.py
@@ -3,7 +3,7 @@ Verify service identities.
 """
 
 
-from . import cryptography, pyopenssl
+from . import common, cryptography, pyopenssl
 from .exceptions import (
     CertificateError,
     SubjectAltNameWarning,
@@ -23,6 +23,7 @@ __all__ = [
     "CertificateError",
     "SubjectAltNameWarning",
     "VerificationError",
+    "common",
     "cryptography",
     "pyopenssl",
 ]

--- a/src/service_identity/common.py
+++ b/src/service_identity/common.py
@@ -2,6 +2,7 @@
 Common verification code.
 """
 
+from __future__ import annotations
 
 import ipaddress
 import re
@@ -133,7 +134,7 @@ def _is_ip_address(pattern):
     return True
 
 
-@attr.s(init=False, slots=True)
+@attr.s(slots=True)
 class DNSPattern:
     """
     A DNS pattern as extracted from certificates.
@@ -144,10 +145,8 @@ class DNSPattern:
 
     _RE_LEGAL_CHARS = re.compile(rb"^[a-z0-9\-_.]+$")
 
-    def __init__(self, pattern):
-        """
-        :type pattern: `bytes`
-        """
+    @classmethod
+    def from_bytes(cls, pattern) -> DNSPattern:
         if not isinstance(pattern, bytes):
             raise TypeError("The DNS pattern must be a bytes string.")
 
@@ -156,9 +155,11 @@ class DNSPattern:
         if pattern == b"" or _is_ip_address(pattern) or b"\0" in pattern:
             raise CertificateError(f"Invalid DNS pattern {pattern!r}.")
 
-        self.pattern = pattern.translate(_TRANS_TO_LOWER)
-        if b"*" in self.pattern:
-            _validate_pattern(self.pattern)
+        pattern = pattern.translate(_TRANS_TO_LOWER)
+        if b"*" in pattern:
+            _validate_pattern(pattern)
+
+        return cls(pattern=pattern)
 
 
 @attr.s(slots=True)
@@ -168,17 +169,17 @@ class IPAddressPattern:
     """
 
     #: The pattern.
-    pattern: Union[ipaddress.IPv4Address, ipaddress.IPv6Address] = attr.ib()
+    pattern: ipaddress.IPv4Address | ipaddress.IPv6Address = attr.ib()
 
     @classmethod
-    def from_bytes(cls, bs):
+    def from_bytes(cls, bs: bytes) -> IPAddressPattern:
         try:
             return cls(pattern=ipaddress.ip_address(bs))
         except ValueError:
             raise CertificateError(f"Invalid IP address pattern {bs!r}.")
 
 
-@attr.s(init=False, slots=True)
+@attr.s(slots=True)
 class URIPattern:
     """
     An URI pattern as extracted from certificates.
@@ -189,7 +190,8 @@ class URIPattern:
     #: The pattern for the DNS part.
     dns_pattern: DNSPattern = attr.ib()
 
-    def __init__(self, pattern: bytes):
+    @classmethod
+    def from_bytes(cls, pattern: bytes) -> URIPattern:
         if not isinstance(pattern, bytes):
             raise TypeError("The URI pattern must be a bytes string.")
 
@@ -197,11 +199,16 @@ class URIPattern:
 
         if b":" not in pattern or b"*" in pattern or _is_ip_address(pattern):
             raise CertificateError(f"Invalid URI pattern {pattern!r}.")
-        self.protocol_pattern, hostname = pattern.split(b":")
-        self.dns_pattern = DNSPattern(hostname)
+
+        protocol_pattern, hostname = pattern.split(b":")
+
+        return cls(
+            protocol_pattern=protocol_pattern,
+            dns_pattern=DNSPattern.from_bytes(hostname),
+        )
 
 
-@attr.s(init=False, slots=True)
+@attr.s(slots=True)
 class SRVPattern:
     """
     An SRV pattern as extracted from certificates.
@@ -212,7 +219,8 @@ class SRVPattern:
     #: The pattern for the DNS part.
     dns_pattern: DNSPattern = attr.ib()
 
-    def __init__(self, pattern: bytes):
+    @classmethod
+    def from_bytes(cls, pattern: bytes) -> SRVPattern:
         if not isinstance(pattern, bytes):
             raise TypeError("The SRV pattern must be a bytes string.")
 
@@ -225,9 +233,11 @@ class SRVPattern:
             or _is_ip_address(pattern)
         ):
             raise CertificateError(f"Invalid SRV pattern {pattern!r}.")
+
         name, hostname = pattern.split(b".", 1)
-        self.name_pattern = name[1:]
-        self.dns_pattern = DNSPattern(hostname)
+        return cls(
+            name_pattern=name[1:], dns_pattern=DNSPattern.from_bytes(hostname)
+        )
 
 
 CertificatePattern = Union[

--- a/src/service_identity/common.py
+++ b/src/service_identity/common.py
@@ -6,6 +6,8 @@ Common verification code.
 import ipaddress
 import re
 
+from typing import Union
+
 import attr
 
 from .exceptions import (
@@ -137,7 +139,8 @@ class DNSPattern:
     A DNS pattern as extracted from certificates.
     """
 
-    pattern = attr.ib()
+    #: The pattern.
+    pattern: bytes = attr.ib()
 
     _RE_LEGAL_CHARS = re.compile(rb"^[a-z0-9\-_.]+$")
 
@@ -164,7 +167,8 @@ class IPAddressPattern:
     An IP address pattern as extracted from certificates.
     """
 
-    pattern = attr.ib()
+    #: The pattern.
+    pattern: Union[ipaddress.IPv4Address, ipaddress.IPv6Address] = attr.ib()
 
     @classmethod
     def from_bytes(cls, bs):
@@ -180,13 +184,12 @@ class URIPattern:
     An URI pattern as extracted from certificates.
     """
 
-    protocol_pattern = attr.ib()
-    dns_pattern = attr.ib()
+    #: The pattern for the protocol part.
+    protocol_pattern: bytes = attr.ib()
+    #: The pattern for the DNS part.
+    dns_pattern: DNSPattern = attr.ib()
 
-    def __init__(self, pattern):
-        """
-        :type pattern: `bytes`
-        """
+    def __init__(self, pattern: bytes):
         if not isinstance(pattern, bytes):
             raise TypeError("The URI pattern must be a bytes string.")
 
@@ -204,13 +207,12 @@ class SRVPattern:
     An SRV pattern as extracted from certificates.
     """
 
-    name_pattern = attr.ib()
-    dns_pattern = attr.ib()
+    #: The pattern for the name part.
+    name_pattern: bytes = attr.ib()
+    #: The pattern for the DNS part.
+    dns_pattern: DNSPattern = attr.ib()
 
-    def __init__(self, pattern):
-        """
-        :type pattern: `bytes`
-        """
+    def __init__(self, pattern: bytes):
         if not isinstance(pattern, bytes):
             raise TypeError("The SRV pattern must be a bytes string.")
 
@@ -226,6 +228,14 @@ class SRVPattern:
         name, hostname = pattern.split(b".", 1)
         self.name_pattern = name[1:]
         self.dns_pattern = DNSPattern(hostname)
+
+
+CertificatePattern = Union[
+    SRVPattern, URIPattern, DNSPattern, IPAddressPattern
+]
+"""
+All possible patterns that can be extracted from a certificate.
+"""
 
 
 @attr.s(init=False, slots=True)

--- a/src/service_identity/cryptography.py
+++ b/src/service_identity/cryptography.py
@@ -54,7 +54,7 @@ def verify_certificate_hostname(
     :returns: ``None``
     """
     verify_service_identity(
-        cert_patterns=extract_ids(certificate),
+        cert_patterns=extract_patterns(certificate),
         obligatory_ids=[DNS_ID(hostname)],
         optional_ids=[],
     )
@@ -84,7 +84,7 @@ def verify_certificate_ip_address(
     .. versionadded:: 18.1.0
     """
     verify_service_identity(
-        cert_patterns=extract_ids(certificate),
+        cert_patterns=extract_patterns(certificate),
         obligatory_ids=[IPAddress_ID(ip_address)],
         optional_ids=[],
     )
@@ -93,7 +93,7 @@ def verify_certificate_ip_address(
 ID_ON_DNS_SRV = ObjectIdentifier("1.3.6.1.5.5.7.8.7")  # id_on_dnsSRV
 
 
-def extract_ids(cert: Certificate) -> list[CertificatePattern]:
+def extract_patterns(cert: Certificate) -> list[CertificatePattern]:
     """
     Extract all valid ID patterns from a certificate for service verification.
 
@@ -141,3 +141,9 @@ def extract_ids(cert: Certificate) -> list[CertificatePattern]:
                     raise CertificateError("Unexpected certificate content.")
 
     return ids
+
+
+extract_ids = extract_patterns
+"""
+Deprecated and never public API.  Use :func:`extract_patterns` instead.
+"""

--- a/src/service_identity/cryptography.py
+++ b/src/service_identity/cryptography.py
@@ -114,13 +114,13 @@ def extract_ids(cert: Certificate) -> list[CertificatePattern]:
     else:
         ids.extend(
             [
-                DNSPattern(name.encode("utf-8"))
+                DNSPattern.from_bytes(name.encode("utf-8"))
                 for name in ext.value.get_values_for_type(DNSName)
             ]
         )
         ids.extend(
             [
-                URIPattern(uri.encode("utf-8"))
+                URIPattern.from_bytes(uri.encode("utf-8"))
                 for uri in ext.value.get_values_for_type(
                     UniformResourceIdentifier
                 )
@@ -136,7 +136,7 @@ def extract_ids(cert: Certificate) -> list[CertificatePattern]:
             if other.type_id == ID_ON_DNS_SRV:
                 srv, _ = decode(other.value)
                 if isinstance(srv, IA5String):
-                    ids.append(SRVPattern(srv.asOctets()))
+                    ids.append(SRVPattern.from_bytes(srv.asOctets()))
                 else:  # pragma: nocover
                     raise CertificateError("Unexpected certificate content.")
 

--- a/src/service_identity/cryptography.py
+++ b/src/service_identity/cryptography.py
@@ -17,9 +17,10 @@ from cryptography.x509.extensions import ExtensionNotFound
 from pyasn1.codec.der.decoder import decode
 from pyasn1.type.char import IA5String
 
-from ._common import (
+from .common import (
     DNS_ID,
     CertificateError,
+    CertificatePattern,
     DNSPattern,
     IPAddress_ID,
     IPAddressPattern,
@@ -92,17 +93,15 @@ def verify_certificate_ip_address(
 ID_ON_DNS_SRV = ObjectIdentifier("1.3.6.1.5.5.7.8.7")  # id_on_dnsSRV
 
 
-def extract_ids(
-    cert: Certificate,
-) -> list[DNSPattern | URIPattern | IPAddressPattern | SRVPattern]:
+def extract_ids(cert: Certificate) -> list[CertificatePattern]:
     """
-    Extract all valid IDs from a certificate for service verification.
+    Extract all valid ID patterns from a certificate for service verification.
 
     :param cert: The certificate to be dissected.
 
     :return: List of IDs.
 
-    .. removed:: 23.1.0
+    .. versionchanged:: 23.1.0
        ``commonName`` is not used as a fallback anymore.
     """
     ids = []

--- a/src/service_identity/pyopenssl.py
+++ b/src/service_identity/pyopenssl.py
@@ -47,7 +47,7 @@ def verify_hostname(connection: SSL.Connection, hostname: str):
     :returns: ``None``
     """
     verify_service_identity(
-        cert_patterns=extract_ids(connection.get_peer_certificate()),
+        cert_patterns=extract_patterns(connection.get_peer_certificate()),
         obligatory_ids=[DNS_ID(hostname)],
         optional_ids=[],
     )
@@ -72,7 +72,7 @@ def verify_ip_address(connection: SSL.Connection, ip_address: str):
     .. versionadded:: 18.1.0
     """
     verify_service_identity(
-        cert_patterns=extract_ids(connection.get_peer_certificate()),
+        cert_patterns=extract_patterns(connection.get_peer_certificate()),
         obligatory_ids=[IPAddress_ID(ip_address)],
         optional_ids=[],
     )
@@ -81,7 +81,7 @@ def verify_ip_address(connection: SSL.Connection, ip_address: str):
 ID_ON_DNS_SRV = ObjectIdentifier("1.3.6.1.5.5.7.8.7")  # id_on_dnsSRV
 
 
-def extract_ids(cert: SSL.X509) -> list[CertificatePattern]:
+def extract_patterns(cert: SSL.X509) -> list[CertificatePattern]:
     """
     Extract all valid ID patterns from a certificate for service verification.
 

--- a/src/service_identity/pyopenssl.py
+++ b/src/service_identity/pyopenssl.py
@@ -9,9 +9,10 @@ from pyasn1.type.char import IA5String
 from pyasn1.type.univ import ObjectIdentifier
 from pyasn1_modules.rfc2459 import GeneralNames
 
-from ._common import (
+from .common import (
     DNS_ID,
     CertificateError,
+    CertificatePattern,
     DNSPattern,
     IPAddress_ID,
     IPAddressPattern,
@@ -80,16 +81,16 @@ def verify_ip_address(connection: SSL.Connection, ip_address: str):
 ID_ON_DNS_SRV = ObjectIdentifier("1.3.6.1.5.5.7.8.7")  # id_on_dnsSRV
 
 
-def extract_ids(cert: SSL.X509):
+def extract_ids(cert: SSL.X509) -> list[CertificatePattern]:
     """
-    Extract all valid IDs from a certificate for service verification.
-
-    If *cert* doesn't contain any identifiers, the ``CN``s are used as DNS-IDs
-    as fallback.
+    Extract all valid ID patterns from a certificate for service verification.
 
     :param cert: The certificate to be dissected.
 
     :return: List of IDs.
+
+    .. versionchanged:: 23.1.0
+       ``commonName`` is not used as a fallback anymore.
     """
     ids = []
     for i in range(cert.get_extension_count()):

--- a/src/service_identity/pyopenssl.py
+++ b/src/service_identity/pyopenssl.py
@@ -100,7 +100,9 @@ def extract_ids(cert: SSL.X509) -> list[CertificatePattern]:
             for n in names:
                 name_string = n.getName()
                 if name_string == "dNSName":
-                    ids.append(DNSPattern(n.getComponent().asOctets()))
+                    ids.append(
+                        DNSPattern.from_bytes(n.getComponent().asOctets())
+                    )
                 elif name_string == "iPAddress":
                     ids.append(
                         IPAddressPattern.from_bytes(
@@ -108,14 +110,16 @@ def extract_ids(cert: SSL.X509) -> list[CertificatePattern]:
                         )
                     )
                 elif name_string == "uniformResourceIdentifier":
-                    ids.append(URIPattern(n.getComponent().asOctets()))
+                    ids.append(
+                        URIPattern.from_bytes(n.getComponent().asOctets())
+                    )
                 elif name_string == "otherName":
                     comp = n.getComponent()
                     oid = comp.getComponentByPosition(0)
                     if oid == ID_ON_DNS_SRV:
                         srv, _ = decode(comp.getComponentByPosition(1))
                         if isinstance(srv, IA5String):
-                            ids.append(SRVPattern(srv.asOctets()))
+                            ids.append(SRVPattern.from_bytes(srv.asOctets()))
                         else:  # pragma: nocover
                             raise CertificateError(
                                 "Unexpected certificate content."

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -22,7 +22,7 @@ from service_identity.common import (
     _validate_pattern,
     verify_service_identity,
 )
-from service_identity.cryptography import extract_ids
+from service_identity.cryptography import extract_patterns
 from service_identity.exceptions import (
     CertificateError,
     DNSMismatch,
@@ -80,7 +80,7 @@ class TestVerifyServiceIdentity:
         id4 = IPAddress_ID(str(ip4))
         id6 = IPAddress_ID(str(ip6))
         rv = verify_service_identity(
-            extract_ids(CERT_EVERYTHING), [id4, id6], []
+            extract_patterns(CERT_EVERYTHING), [id4, id6], []
         )
 
         assert [

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -3,9 +3,9 @@ import pickle
 
 import pytest
 
-import service_identity._common
+import service_identity.common
 
-from service_identity._common import (
+from service_identity.common import (
     DNS_ID,
     SRV_ID,
     URI_ID,
@@ -181,7 +181,7 @@ class TestDNS_ID:
         """
         Raise ImportError if idna is missing and a non-ASCII DNS-ID is passed.
         """
-        monkeypatch.setattr(service_identity._common, "idna", None)
+        monkeypatch.setattr(service_identity.common, "idna", None)
         with pytest.raises(ImportError):
             DNS_ID("f\xf8\xf8.com")
 
@@ -189,7 +189,7 @@ class TestDNS_ID:
         """
         7bit-ASCII DNS-IDs work no matter whether idna is present or not.
         """
-        monkeypatch.setattr(service_identity._common, "idna", None)
+        monkeypatch.setattr(service_identity.common, "idna", None)
         dns = DNS_ID("foo.com")
         assert b"foo.com" == dns.hostname
 

--- a/tests/test_cryptography.py
+++ b/tests/test_cryptography.py
@@ -81,8 +81,8 @@ class TestExtractIDs:
         """
         rv = extract_ids(X509_DNS_ONLY)
         assert [
-            DNSPattern(b"www.twistedmatrix.com"),
-            DNSPattern(b"twistedmatrix.com"),
+            DNSPattern.from_bytes(b"www.twistedmatrix.com"),
+            DNSPattern.from_bytes(b"twistedmatrix.com"),
         ] == rv
 
     def test_cn_ids_are_ignored(self):
@@ -96,7 +96,7 @@ class TestExtractIDs:
         Returns the correct URIPattern from a certificate.
         """
         rv = extract_ids(X509_OTHER_NAME)
-        assert [URIPattern(b"http://example.com/")] == [
+        assert [URIPattern.from_bytes(b"http://example.com/")] == [
             id for id in rv if isinstance(id, URIPattern)
         ]
 
@@ -107,10 +107,12 @@ class TestExtractIDs:
         rv = extract_ids(CERT_EVERYTHING)
 
         assert [
-            DNSPattern(pattern=b"service.identity.invalid"),
-            DNSPattern(pattern=b"*.wildcard.service.identity.invalid"),
-            DNSPattern(pattern=b"service.identity.invalid"),
-            DNSPattern(pattern=b"single.service.identity.invalid"),
+            DNSPattern.from_bytes(pattern=b"service.identity.invalid"),
+            DNSPattern.from_bytes(
+                pattern=b"*.wildcard.service.identity.invalid"
+            ),
+            DNSPattern.from_bytes(pattern=b"service.identity.invalid"),
+            DNSPattern.from_bytes(pattern=b"single.service.identity.invalid"),
             IPAddressPattern(pattern=ipaddress.IPv4Address("1.1.1.1")),
             IPAddressPattern(pattern=ipaddress.IPv6Address("::1")),
             IPAddressPattern(pattern=ipaddress.IPv4Address("2.2.2.2")),

--- a/tests/test_cryptography.py
+++ b/tests/test_cryptography.py
@@ -5,7 +5,7 @@ import pytest
 from cryptography.hazmat.backends import default_backend
 from cryptography.x509 import load_pem_x509_certificate
 
-from service_identity._common import (
+from service_identity.common import (
     DNS_ID,
     DNSPattern,
     IPAddress_ID,

--- a/tests/test_cryptography.py
+++ b/tests/test_cryptography.py
@@ -13,7 +13,7 @@ from service_identity.common import (
     URIPattern,
 )
 from service_identity.cryptography import (
-    extract_ids,
+    extract_patterns,
     verify_certificate_hostname,
     verify_certificate_ip_address,
 )
@@ -79,7 +79,7 @@ class TestExtractIDs:
         """
         Returns the correct DNSPattern from a certificate.
         """
-        rv = extract_ids(X509_DNS_ONLY)
+        rv = extract_patterns(X509_DNS_ONLY)
         assert [
             DNSPattern.from_bytes(b"www.twistedmatrix.com"),
             DNSPattern.from_bytes(b"twistedmatrix.com"),
@@ -89,13 +89,13 @@ class TestExtractIDs:
         """
         commonName is not supported anymore and therefore ignored.
         """
-        assert [] == extract_ids(X509_CN_ONLY)
+        assert [] == extract_patterns(X509_CN_ONLY)
 
     def test_uri(self):
         """
         Returns the correct URIPattern from a certificate.
         """
-        rv = extract_ids(X509_OTHER_NAME)
+        rv = extract_patterns(X509_OTHER_NAME)
         assert [URIPattern.from_bytes(b"http://example.com/")] == [
             id for id in rv if isinstance(id, URIPattern)
         ]
@@ -104,7 +104,7 @@ class TestExtractIDs:
         """
         Returns IP patterns.
         """
-        rv = extract_ids(CERT_EVERYTHING)
+        rv = extract_patterns(CERT_EVERYTHING)
 
         assert [
             DNSPattern.from_bytes(pattern=b"service.identity.invalid"),

--- a/tests/test_pyopenssl.py
+++ b/tests/test_pyopenssl.py
@@ -99,8 +99,8 @@ class TestExtractIDs:
         """
         rv = extract_ids(CERT_DNS_ONLY)
         assert [
-            DNSPattern(b"www.twistedmatrix.com"),
-            DNSPattern(b"twistedmatrix.com"),
+            DNSPattern.from_bytes(b"www.twistedmatrix.com"),
+            DNSPattern.from_bytes(b"twistedmatrix.com"),
         ] == rv
 
     def test_cn_ids_are_ignored(self):
@@ -114,7 +114,7 @@ class TestExtractIDs:
         Returns the correct URIPattern from a certificate.
         """
         rv = extract_ids(CERT_OTHER_NAME)
-        assert [URIPattern(b"http://example.com/")] == [
+        assert [URIPattern.from_bytes(b"http://example.com/")] == [
             id for id in rv if isinstance(id, URIPattern)
         ]
 
@@ -125,10 +125,12 @@ class TestExtractIDs:
         rv = extract_ids(CERT_EVERYTHING)
 
         assert [
-            DNSPattern(pattern=b"service.identity.invalid"),
-            DNSPattern(pattern=b"*.wildcard.service.identity.invalid"),
-            DNSPattern(pattern=b"service.identity.invalid"),
-            DNSPattern(pattern=b"single.service.identity.invalid"),
+            DNSPattern.from_bytes(pattern=b"service.identity.invalid"),
+            DNSPattern.from_bytes(
+                pattern=b"*.wildcard.service.identity.invalid"
+            ),
+            DNSPattern.from_bytes(pattern=b"service.identity.invalid"),
+            DNSPattern.from_bytes(pattern=b"single.service.identity.invalid"),
             IPAddressPattern(pattern=ipaddress.IPv4Address("1.1.1.1")),
             IPAddressPattern(pattern=ipaddress.IPv6Address("::1")),
             IPAddressPattern(pattern=ipaddress.IPv4Address("2.2.2.2")),

--- a/tests/test_pyopenssl.py
+++ b/tests/test_pyopenssl.py
@@ -17,7 +17,7 @@ from service_identity.exceptions import (
     VerificationError,
 )
 from service_identity.pyopenssl import (
-    extract_ids,
+    extract_patterns,
     verify_hostname,
     verify_ip_address,
 )
@@ -97,7 +97,7 @@ class TestExtractIDs:
         """
         Returns the correct DNSPattern from a certificate.
         """
-        rv = extract_ids(CERT_DNS_ONLY)
+        rv = extract_patterns(CERT_DNS_ONLY)
         assert [
             DNSPattern.from_bytes(b"www.twistedmatrix.com"),
             DNSPattern.from_bytes(b"twistedmatrix.com"),
@@ -107,13 +107,13 @@ class TestExtractIDs:
         """
         commonName is not supported anymore and therefore ignored.
         """
-        assert [] == extract_ids(CERT_CN_ONLY)
+        assert [] == extract_patterns(CERT_CN_ONLY)
 
     def test_uri(self):
         """
         Returns the correct URIPattern from a certificate.
         """
-        rv = extract_ids(CERT_OTHER_NAME)
+        rv = extract_patterns(CERT_OTHER_NAME)
         assert [URIPattern.from_bytes(b"http://example.com/")] == [
             id for id in rv if isinstance(id, URIPattern)
         ]
@@ -122,7 +122,7 @@ class TestExtractIDs:
         """
         Returns IP patterns.
         """
-        rv = extract_ids(CERT_EVERYTHING)
+        rv = extract_patterns(CERT_EVERYTHING)
 
         assert [
             DNSPattern.from_bytes(pattern=b"service.identity.invalid"),

--- a/tests/test_pyopenssl.py
+++ b/tests/test_pyopenssl.py
@@ -4,7 +4,7 @@ import pytest
 
 from OpenSSL.crypto import FILETYPE_PEM, load_certificate
 
-from service_identity._common import (
+from service_identity.common import (
     DNS_ID,
     DNSPattern,
     IPAddress_ID,

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,7 +1,7 @@
 from cryptography.hazmat.backends import default_backend
 from cryptography.x509 import load_pem_x509_certificate
 
-from service_identity.cryptography import extract_ids
+from service_identity.cryptography import extract_patterns
 
 
 # Test certificates
@@ -45,7 +45,7 @@ fJiBDvG/iDAJISgkrR1heuX/e+yWfx7RvqGlMLIE35d+0MhWy92Jzejbl8fJdr4C
 Kulh/pV07MWAUZxscUPtWmPo
 -----END CERTIFICATE-----"""
 
-DNS_IDS = extract_ids(
+DNS_IDS = extract_patterns(
     load_pem_x509_certificate(PEM_DNS_ONLY, default_backend())
 )
 


### PR DESCRIPTION
There's a ton of code that probably won't ever be used for verification anymore, so let's expose it for people to easily introspect certificates.