### PR TITLE
Drop deprecated packaging metadata

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,7 +64,7 @@ exclude_patterns = ["_build"]
 
 html_theme = "furo"
 html_theme_options = {
-    "top_of_page_button": None,
+    "top_of_page_buttons": [],
     "light_css_variables": {
         "font-stack": "Inter, sans-serif",
         "font-stack--monospace": "BerkeleyMono, MonoLisa, ui-monospace, "

--- a/src/service_identity/__init__.py
+++ b/src/service_identity/__init__.py
@@ -29,35 +29,10 @@ __all__ = [
 
 
 def __getattr__(name: str) -> str:
-    dunder_to_metadata = {
-        "__version__": "version",
-        "__description__": "summary",
-        "__uri__": "",
-        "__url__": "",
-        "__email__": "",
-    }
-    if name not in dunder_to_metadata:
+    if name != "__version__":
         msg = f"module {__name__} has no attribute {name}"
         raise AttributeError(msg)
 
-    import warnings
+    from importlib.metadata import version
 
-    from importlib.metadata import metadata
-
-    warnings.warn(
-        f"Accessing service_identity.{name} is deprecated and will be "
-        "removed in a future release. Use importlib.metadata directly "
-        "to query packaging metadata.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-
-    meta = metadata("service-identity")
-
-    if name in ("__uri__", "__url__"):
-        return meta["Project-URL"].split(" ", 1)[1]
-
-    if name == "__email__":
-        return meta["Author-email"].split("<", 1)[1].rstrip(">")
-
-    return meta[dunder_to_metadata[name]]
+    return version("service-identity")

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -10,38 +10,10 @@ class TestLegacyMetadataHack:
         """
         service_identity.__version__ returns the correct version.
         """
-        with pytest.deprecated_call():
-            assert (
-                metadata.version("service-identity")
-                == service_identity.__version__
-            )
-
-    def test_description(self):
-        """
-        service_identity.__description__ returns the correct description.
-        """
-        with pytest.deprecated_call():
-            assert (
-                "Service identity verification for pyOpenSSL & cryptography."
-                == service_identity.__description__
-            )
-
-    @pytest.mark.parametrize("name", ["uri", "url"])
-    def test_uri(self, name):
-        """
-        service_identity.__uri__ & __url__ return the correct project URL.
-        """
-        with pytest.deprecated_call():
-            assert "https://service-identity.readthedocs.io/" == getattr(
-                service_identity, f"__{name}__"
-            )
-
-    def test_email(self):
-        """
-        service_identity.__email__ returns Hynek's email address.
-        """
-        with pytest.deprecated_call():
-            assert "hs@ox.cx" == service_identity.__email__
+        assert (
+            metadata.version("service-identity")
+            == service_identity.__version__
+        )
 
     def test_does_not_exist(self):
         """


### PR DESCRIPTION
Keeping `__version__` around since it's still widely used, unfortunately.

Fixes #68