### PR TITLE
Replace pyasn1 by cryptography.hazmat.asn1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ You can find out backwards-compatibility policy [here](https://github.com/pyca/s
 
 - *service-identity* now uses *cryptography*'s Rust-based ASN.1 decoder and doesn't depend on *pyasn1* and *pyasn1-modules* anymore.
   As a result, the oldest supported pyOpenSSL backend combination is now *pyOpenSSL* 26.1.0 with *cryptography* 47.0.0.
+  [#95](https://github.com/pyca/service-identity/pull/95)
 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ You can find out backwards-compatibility policy [here](https://github.com/pyca/s
   [#93](https://github.com/pyca/service-identity/pull/93)
 
 
+### Changed
+
+- *service-identity* now uses *cryptography*'s Rust-based ASN.1 decoder and doesn't depend on *pyasn1* and *pyasn1-modules* anymore.
+  As a result, the oldest supported pyOpenSSL backend combination is now *pyOpenSSL* 26.1.0 with *cryptography* 47.0.0.
+
+
 ### Fixed
 
 - Verifying a single-label hostname (e.g. `localhost`) against a wildcard certificate pattern now raises `VerificationError` cleanly instead of crashing with an opaque `ValueError`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,7 @@ classifiers = [
 dependencies = [
     # Keep in-sync with tests/constraints/*.
     "attrs>=19.1.0",
-    "pyasn1-modules",
-    "pyasn1",
-    "cryptography",
+    "cryptography>=47",
 ]
 
 [project.urls]

--- a/src/service_identity/cryptography.py
+++ b/src/service_identity/cryptography.py
@@ -8,6 +8,7 @@ import warnings
 
 from typing import Sequence
 
+from cryptography.hazmat import asn1
 from cryptography.x509 import (
     Certificate,
     DNSName,
@@ -18,8 +19,6 @@ from cryptography.x509 import (
     UniformResourceIdentifier,
 )
 from cryptography.x509.extensions import ExtensionNotFound
-from pyasn1.codec.der.decoder import decode
-from pyasn1.type.char import IA5String
 
 from .exceptions import CertificateError
 from .hazmat import (
@@ -159,12 +158,13 @@ def extract_patterns(cert: Certificate) -> Sequence[CertificatePattern]:
         )
         for other in ext.value.get_values_for_type(OtherName):
             if other.type_id == ID_ON_DNS_SRV:
-                srv, _ = decode(other.value)
-                if isinstance(srv, IA5String):
-                    ids.append(SRVPattern.from_bytes(srv.asOctets()))
-                else:  # pragma: no cover
+                try:
+                    srv = asn1.decode_der(asn1.IA5String, other.value)
+                except ValueError as e:
                     msg = "Unexpected certificate content."
-                    raise CertificateError(msg)
+                    raise CertificateError(msg) from e
+
+                ids.append(SRVPattern.from_bytes(srv.as_str().encode("ascii")))
 
     return ids
 

--- a/tests/constraints/oldest-cryptography.txt
+++ b/tests/constraints/oldest-cryptography.txt
@@ -1,2 +1,2 @@
 attrs==19.1.0
-cryptography<3
+cryptography==47.0.0

--- a/tests/constraints/oldest-pyopenssl.txt
+++ b/tests/constraints/oldest-pyopenssl.txt
@@ -1,3 +1,3 @@
 attrs==19.1.0
-cryptography<35
-pyOpenSSL==17.1.0
+cryptography==47.0.0
+pyOpenSSL==26.1.0

--- a/tests/test_cryptography.py
+++ b/tests/test_cryptography.py
@@ -3,9 +3,15 @@ import ipaddress
 import pytest
 
 from cryptography.hazmat.backends import default_backend
-from cryptography.x509 import load_pem_x509_certificate
+from cryptography.x509 import (
+    ExtensionOID,
+    OtherName,
+    SubjectAlternativeName,
+    load_pem_x509_certificate,
+)
 
 from service_identity.cryptography import (
+    ID_ON_DNS_SRV,
     extract_ids,
     extract_patterns,
     verify_certificate_hostname,
@@ -22,6 +28,7 @@ from service_identity.hazmat import (
     DNSPattern,
     IPAddress_ID,
     IPAddressPattern,
+    SRVPattern,
     URIPattern,
 )
 
@@ -129,6 +136,48 @@ class TestExtractPatterns:
         assert [URIPattern.from_bytes(b"http://example.com/")] == [
             id for id in rv if isinstance(id, URIPattern)
         ]
+
+    def test_srv(self):
+        """
+        Returns the correct SRVPattern from a certificate.
+        """
+        rv = extract_patterns(X509_OTHER_NAME)
+        assert [SRVPattern.from_bytes(b"_xmpp-client.example.net")] == [
+            id for id in rv if isinstance(id, SRVPattern)
+        ]
+
+    def test_malformed_srv_other_name(self):
+        """
+        Malformed DER in a SRV-ID otherName raises a CertificateError.
+        """
+
+        class Extension:
+            def __init__(self, value):
+                self.value = value
+
+        class Extensions:
+            def __init__(self, value):
+                self._value = value
+
+            def get_extension_for_oid(self, oid):
+                assert oid == ExtensionOID.SUBJECT_ALTERNATIVE_NAME
+
+                return Extension(self._value)
+
+        class Certificate:
+            def __init__(self, san):
+                self.extensions = Extensions(san)
+
+        cert = Certificate(
+            SubjectAlternativeName(
+                [OtherName(ID_ON_DNS_SRV, b"\x16\x03abc\x00")]
+            )
+        )
+
+        with pytest.raises(
+            CertificateError, match=r"Unexpected certificate content\."
+        ):
+            extract_patterns(cert)
 
     def test_ip(self):
         """


### PR DESCRIPTION
Alright, barely a decade later, LFG!

Given that cryptography.hazmat.asn1 is marked as provisional, should we wait a bit with landing this, though?

Fixes #20